### PR TITLE
Update transaction fee 0.25 -> 0.30

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -38,7 +38,7 @@ export default (): IConfig => ({
     url: process.env.SUBGRAPH_URL || '',
   },
   fees: {
-    wrapTokenFeePercentageBps: 0.25 * 100, // 0.25% in basis points
+    wrapTokenFeePercentageBps: 0.3 * 100, // 0.3% in basis points
   },
   blockchain: {
     chainId: BigInt(process.env.CHAIN_ID || 1),

--- a/src/wrap-token-fees/wrap-token-fees.service.spec.ts
+++ b/src/wrap-token-fees/wrap-token-fees.service.spec.ts
@@ -37,8 +37,8 @@ describe('WrapTokenFeesService tests', () => {
         tokenAmount,
       });
 
-      expect(utils.formatUnits(result.feeAmount, 6)).toEqual('0.25');
-      expect(utils.formatUnits(result.amountAfterFee, 6)).toEqual('99.75');
+      expect(utils.formatUnits(result.feeAmount, 6)).toEqual('0.3');
+      expect(utils.formatUnits(result.amountAfterFee, 6)).toEqual('99.7');
     });
   });
 });

--- a/src/wrap-token-transaction/wrap-token-transaction.controller.spec.ts
+++ b/src/wrap-token-transaction/wrap-token-transaction.controller.spec.ts
@@ -154,9 +154,9 @@ describe('WrapTokenTransactionController', () => {
           id: transaction.id,
           tokenAmount: dto.tokenAmount,
           status: dto.status,
-          feePercentageBps: 25,
-          feeAmount: '5',
-          amountAfterFee: '1995',
+          feePercentageBps: 30,
+          feeAmount: '6',
+          amountAfterFee: '1994',
         }),
       );
 
@@ -165,8 +165,8 @@ describe('WrapTokenTransactionController', () => {
       ).findOne({ where: { id: transaction.id } });
 
       expect(updatedTransaction?.tokenAmount).toBe(dto.tokenAmount);
-      expect(updatedTransaction?.feeAmount).toBe('5');
-      expect(updatedTransaction?.amountAfterFee).toBe('1995');
+      expect(updatedTransaction?.feeAmount).toBe('6');
+      expect(updatedTransaction?.amountAfterFee).toBe('1994');
       expect(updatedTransaction?.status).toBe(dto.status);
     });
 

--- a/src/wrap-token/wrap-token.controller.spec.ts
+++ b/src/wrap-token/wrap-token.controller.spec.ts
@@ -77,9 +77,9 @@ describe('WrapTokenController', () => {
           tokenAmount: dto.tokenAmount,
           status: WrapTokenTransactionStatus.CREATED,
           paymentId: body.paymentId,
-          feePercentageBps: 25,
-          feeAmount: '2500',
-          amountAfterFee: '997500',
+          feePercentageBps: 30,
+          feeAmount: '3000',
+          amountAfterFee: '997000',
         }),
       );
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the fee percentage for token wrapping from 0.25% to 0.3%. All related calculations and displayed values now reflect this change.
- **Tests**
  - Adjusted test expectations to match the updated fee percentage and corresponding fee calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->