### PR TITLE
Add nonce and safe tx hash

### DIFF
--- a/src/wrap-token-transaction-m2m/wrap-token-transaction-m2m.controller.spec.ts
+++ b/src/wrap-token-transaction-m2m/wrap-token-transaction-m2m.controller.spec.ts
@@ -217,12 +217,18 @@ describe('WrapTokenTransactionController', () => {
         wallelTransactions: [
           {
             paymentId: tx_received.paymentId,
+            safeTxHash: 'tx_1_hash',
+            safeNonce: 1,
           },
           {
             paymentId: tx_other_status.paymentId,
+            safeTxHash: 'tx_2_hash',
+            safeNonce: 2,
           },
           {
             paymentId: tx_no_tari_tx_id.paymentId,
+            safeTxHash: 'tx_3_hash',
+            safeNonce: 3,
           },
         ],
       };
@@ -245,14 +251,20 @@ describe('WrapTokenTransactionController', () => {
           expect.objectContaining({
             id: tx_received.id,
             status: WrapTokenTransactionStatus.SAFE_TRANSACTION_CREATED,
+            safeTxHash: 'tx_1_hash',
+            safeNonce: 1,
           }),
           expect.objectContaining({
             id: tx_other_status.id,
             status: WrapTokenTransactionStatus.CREATED,
+            safeTxHash: null,
+            safeNonce: null,
           }),
           expect.objectContaining({
             id: tx_no_tari_tx_id.id,
             status: WrapTokenTransactionStatus.TOKENS_RECEIVED,
+            safeTxHash: null,
+            safeNonce: null,
           }),
         ]),
       );

--- a/src/wrap-token-transaction-m2m/wrap-token-transaction-m2m.dto.ts
+++ b/src/wrap-token-transaction-m2m/wrap-token-transaction-m2m.dto.ts
@@ -2,8 +2,10 @@ import { Type } from 'class-transformer';
 import {
   IsArray,
   IsNotEmpty,
+  IsNumber,
   IsNumberString,
   IsOptional,
+  IsString,
   IsUUID,
   ValidateNested,
 } from 'class-validator';
@@ -38,6 +40,14 @@ export class TransactionProposedDTO {
   @IsUUID()
   @IsNotEmpty()
   paymentId: string;
+
+  @IsNotEmpty()
+  @IsString()
+  safeTxHash: string;
+
+  @IsNotEmpty()
+  @IsNumber()
+  safeNonce: number;
 }
 
 export class TransactionProposedRequestDTO {

--- a/src/wrap-token-transaction-m2m/wrap-token-transaction-m2m.service.ts
+++ b/src/wrap-token-transaction-m2m/wrap-token-transaction-m2m.service.ts
@@ -63,6 +63,8 @@ export class WrapTokenTransactionM2MService extends TypeOrmCrudService<WrapToken
         },
         {
           status: WrapTokenTransactionStatus.SAFE_TRANSACTION_CREATED,
+          safeTxHash: transaction.safeTxHash,
+          safeNonce: transaction.safeNonce,
         },
       );
     }

--- a/wxtm-bridge-backend-api-node/package.json
+++ b/wxtm-bridge-backend-api-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tari-project/wxtm-bridge-backend-api-node",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new fields for transaction proposals: users can now provide and view `safeTxHash` and `safeNonce` when updating transactions.
- **Bug Fixes**
  - Improved validation and handling to ensure `safeTxHash` and `safeNonce` are correctly set or cleared based on transaction status.
- **Chores**
  - Updated package version to 0.1.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->